### PR TITLE
feat: add GitHub Actions CI/CD pipeline with separated workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI - Build & Test
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test & Lint
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        
+      - name: Run linter
+        run: pnpm --filter chicago-game lint
+        
+      - name: Run type check
+        run: pnpm --filter chicago-game check
+        
+      - name: Build application
+        run: pnpm --filter chicago-game build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,64 @@
+name: CD - Deploy to Production
+
+on:
+  release:
+    types: [published]
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+jobs:
+  deploy:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        
+      - name: Run tests before deployment
+        run: |
+          pnpm --filter chicago-game lint
+          pnpm --filter chicago-game check
+          pnpm --filter chicago-game build
+        
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+        
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }}
+        working-directory: ./src/apps/chicago-game
+        
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }}
+        working-directory: ./src/apps/chicago-game
+        
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }} --meta version=${{ github.event.release.tag_name }} --meta commit=${{ github.sha }}
+        working-directory: ./src/apps/chicago-game
+        
+      - name: Comment on Release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.repos.createReleaseComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: context.payload.release.id,
+              body: '🚀 Successfully deployed version ${{ github.event.release.tag_name }} to production!\n\nCommit: ${{ github.sha }}'
+            });

--- a/README.md
+++ b/README.md
@@ -1,3 +1,96 @@
 # Chicago
 
 Keep track of players score in the classic card game Chicago.
+
+## Development
+
+This is a monorepo built with pnpm and Turbo. The main application is a SvelteKit app located in `src/apps/chicago-game/`.
+
+### Prerequisites
+
+- Node.js 20+
+- pnpm 8+
+
+### Getting Started
+
+```bash
+# Install dependencies
+pnpm install
+
+# Start development server
+pnpm --filter chicago-game dev
+```
+
+### Scripts
+
+```bash
+# Build for production
+pnpm --filter chicago-game build
+
+# Run linting
+pnpm --filter chicago-game lint
+
+# Run type checking
+pnpm --filter chicago-game check
+
+# Format code
+pnpm --filter chicago-game format
+```
+
+## Deployment
+
+This project uses separate GitHub Actions workflows for CI and CD:
+
+### CI Pipeline (`ci.yml`)
+**Triggers:** Push to main/develop, Pull Requests
+- Runs linting and code formatting checks
+- Performs TypeScript type checking
+- Builds the application to verify compilation
+- **No deployment** - validation only
+
+### CD Pipeline (`deploy.yml`)
+**Triggers:** GitHub Releases (published)
+- Runs full test suite before deployment
+- Deploys to production on Vercel
+- Comments on the release with deployment status
+
+### Workflow Benefits
+- **Clean Separation:** CI validates code quality, CD handles deployment
+- **Release Control:** Production deploys only happen on tagged releases
+- **Fast Feedback:** CI runs quickly without deployment overhead
+- **Safety:** Tests must pass before any deployment
+
+### Required GitHub Secrets
+
+Add these secrets to your GitHub repository for deployment:
+
+1. `VERCEL_TOKEN` - Vercel API token (create at https://vercel.com/account/tokens)
+2. `VERCEL_ORG_ID` - Your Vercel organization ID
+3. `VERCEL_PROJECT_ID` - Your Vercel project ID
+
+### Getting Vercel IDs
+
+```bash
+# Install Vercel CLI
+npm i -g vercel
+
+# Login and link project
+cd src/apps/chicago-game
+vercel
+
+# Get project info (shows org and project IDs)
+vercel project ls
+```
+
+### Creating a Release
+
+To deploy to production:
+
+1. Merge your changes to `main`
+2. Create a new release on GitHub:
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+3. Or use GitHub's web interface to create a release
+4. The deployment workflow will automatically trigger

--- a/src/apps/chicago-game/.gitignore
+++ b/src/apps/chicago-game/.gitignore
@@ -21,3 +21,5 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+.vercel


### PR DESCRIPTION
This pull request sets up automated CI/CD workflows for the project and documents the development and deployment process. The main changes are the addition of GitHub Actions for continuous integration and deployment, improvements to developer onboarding in the `README.md`, and updates to `.gitignore` for Vercel compatibility.

**CI/CD Automation:**

* Added a GitHub Actions workflow (`.github/workflows/ci.yml`) for CI that runs on pushes to `main`/`develop` and on pull requests, performing linting, type checking, and building the app for validation.
* Added a GitHub Actions workflow (`.github/workflows/deploy.yml`) for CD that triggers on published releases, runs tests, deploys to Vercel, and comments on the release with deployment status.

**Documentation Improvements:**

* Updated `README.md` to include detailed development instructions, scripts, CI/CD workflow explanations, required secrets, and deployment steps.

**Project Configuration:**

* Updated `.gitignore` in `src/apps/chicago-game/` to exclude the `.vercel` directory, preventing local Vercel files from being committed.